### PR TITLE
fix arbundles patch is not applied on postinstall

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
     "dev": "next dev",
     "build": "next build && next export",
     "start": "next start",
-    "lint": "next lint"
+    "lint": "next lint",
+    "postinstall": "patch-package"
   },
   "dependencies": {
     "@ant-design/icons": "^4.7.0",


### PR DESCRIPTION
See:
- https://github.com/Bundlr-Network/arbundles/issues/15
- https://github.com/Bundlr-Network/arbundles/pull/18
- patches/arbundles+0.3.0.patch

Follow-up of https://github.com/penta-fun/sol-nft-tools/pull/1