### PR TITLE
add verified creator filter to getMints

### DIFF
--- a/util/get-mints.ts
+++ b/util/get-mints.ts
@@ -19,6 +19,12 @@ export const getMints = async (creatorId: string, url: string) => {
             bytes: creatorId,
           },
         },
+        {
+          memcmp: {
+            offset: 358, // first creator verified position
+            bytes: "2", // 1 as base58 string
+          },
+        },
       ],
     }
   );


### PR DESCRIPTION
This adds an extra memcp filter to getMints to check that the first creator is verified to protect against fakes.