### PR TITLE
Throw error if youre missing RPC environment variable

### DIFF
--- a/.env.local.example
+++ b/.env.local.example
@@ -1,0 +1,1 @@
+NEXT_PUBLIC_RPC=your-rpc-endpoint

--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -28,7 +28,7 @@ import {
   InfoIcon,
   SendIcon,
 } from "../components/icons";
-const endpoint = process.env.NEXT_PUBLIC_RPC!;
+const endpoint = process.env.NEXT_PUBLIC_RPC;
 
 const WalletProvider = dynamic(
   () => import("../contexts/ClientWalletProvider"),
@@ -52,6 +52,9 @@ const Providers = ({ children }: { children: React.ReactNode }) => {
 
 function Context({ children }: { children: React.ReactNode }) {
   const { setAlertState } = useAlert();
+  if (endpoint === undefined) {
+    throw new Error('Missing NEXT_PUBLIC_RPC in env file');
+  }
 
   return (
     <ConnectionProvider


### PR DESCRIPTION
Fixes #9 

Also adds a `.env.local.example` file to hopefully save some folks some time.